### PR TITLE
Pindah format badge navigasi ke bentuk svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint {common,config,misc,plugin,router,test}/**/*.js *.js"
   },
   "author": "bellshade",
-  "license": "ISC",
   "dependencies": {
     "@octokit/rest": "^18.10.0",
     "@xmldom/xmldom": "^0.7.5",
@@ -33,7 +32,7 @@
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^25.2.4",
-    "istextorbinary": "^6.0.0",
+    "is-svg": "^4.3.2",
     "jest": "^27.3.1",
     "nodemon": "^2.0.12",
     "prettier": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "author": "bellshade",
   "license": "ISC",
   "dependencies": {
-    "@fontsource/poppins": "^4.5.0",
     "@octokit/rest": "^18.10.0",
-    "canvas": "^2.8.0",
+    "@xmldom/xmldom": "^0.7.5",
+    "badge-maker": "^3.3.1",
     "discord-webhook-node": "^1.1.8",
     "fastify": "^3.22.0",
     "fastify-autoload": "^3.9.0",

--- a/router/badge/config.js
+++ b/router/badge/config.js
@@ -18,7 +18,8 @@ const nextImg = getImage("static/next.png");
 const prevImg = getImage("static/previous.png");
 
 const drawer = (text, type = "next") => {
-  if (!NAVIGATION_TYPES.includes(type)) throw new Error("Invalid type");
+  if (!text || text === "") throw new Error("Text is Required");
+  if (!NAVIGATION_TYPES.includes(type)) throw new Error("Invalid Type");
 
   const doc = new DOMParser().parseFromString(
     makeBadge({
@@ -60,13 +61,14 @@ const drawer = (text, type = "next") => {
   secG.removeChild(secG.getElementsByTagNameNS(NS, "text")[1]);
 
   switch (type) {
-    case "next":
+    case "next": {
       image.setAttributeNS(NS, "x", (8.9 / 10) * parentAttr.width);
 
       secG.appendChild(image);
 
       break;
-    case "previous":
+    }
+    case "previous": {
       image.setAttributeNS(NS, "x", (1 / 22) * parentAttr.width);
 
       const [firstRectCloned, secRectCloned] = Object.entries(
@@ -101,6 +103,7 @@ const drawer = (text, type = "next") => {
       labelText.setAttributeNS(NS, "x", (11.5 / 20) * 10 * parentAttr.width);
 
       break;
+    }
   }
 
   return doc.toString();
@@ -109,4 +112,6 @@ const drawer = (text, type = "next") => {
 module.exports = {
   NAVIGATION_TYPES,
   drawer,
+  nextImg,
+  prevImg,
 };

--- a/router/badge/config.js
+++ b/router/badge/config.js
@@ -1,47 +1,112 @@
 const fs = require("fs");
 const path = require("path");
+const { makeBadge } = require("badge-maker");
+const { DOMParser } = require("@xmldom/xmldom");
 
-// const poppins = path.dirname(require.resolve("@fontsource/poppins"));
-const { createCanvas, Image } = require("canvas");
-
-// const allRegularFont = path.join(poppins, "files/poppins-all-400-normal.woff");
-// registerFont(allRegularFont, { family: "Poppins" });
-
-const DEFAULT_FONT = "18px Poppins";
-const GREY_RECT = "#555555";
-const GREEN_RECT = "#44cc11";
-
+const NS = "http://www.w3.org/2000/svg";
 const NAVIGATION_TYPES = ["next", "previous"];
 
 const getImage = (pathToImage) => {
   const filePath = path.join(__dirname, pathToImage);
 
-  return (ctx, sx, sy) => {
-    const image = new Image();
-    const binary = fs.readFileSync(filePath);
+  const base64 = fs.readFileSync(filePath, "base64");
 
-    image.onload = () => ctx.drawImage(image, sx, sy);
-    image.src = binary;
-  };
+  return `data:image/png;base64,${base64}`;
 };
 
-function getTextWidth(text) {
-  const canvas = createCanvas();
-  const ctx = canvas.getContext("2d");
+const nextImg = getImage("static/next.png");
+const prevImg = getImage("static/previous.png");
 
-  ctx.font = DEFAULT_FONT;
+const drawer = (text, type = "next") => {
+  if (!NAVIGATION_TYPES.includes(type)) throw new Error("Invalid type");
 
-  const metrics = ctx.measureText(text);
-  return metrics.width + 31;
-}
+  const doc = new DOMParser().parseFromString(
+    makeBadge({
+      label: text,
+      message: type === "next" ? ">" : "<",
+      labelColor: "#555",
+      color: "#4c1",
+      style: "for-the-badge",
+    }),
+    "image/svg+xml"
+  );
+
+  const href = type === "next" ? nextImg : prevImg;
+  const image = doc.createElementNS(NS, "image");
+  image.setAttributeNS(NS, "href", href);
+  image.setAttributeNS(NS, "width", "15");
+  image.setAttributeNS(NS, "height", "15");
+
+  const parentAttr = Object.entries(
+    doc.documentElement.getElementsByTagNameNS(NS, "svg")._node.attributes
+  )
+    .filter((e) => !isNaN(e[0]))
+    .map((e) => e[1])
+    .map((e) => ({
+      [e.name]: e.value,
+    }))
+    .reduce((curr, acc) => Object.assign(curr, acc));
+
+  const [firstG, secG] = Object.entries(
+    doc.documentElement.getElementsByTagNameNS(NS, "g")
+  )
+    .filter((e) => !isNaN(e[0]))
+    .map((e) => e[1]);
+
+  // Center image vertical
+  image.setAttributeNS(NS, "y", (2 / 10) * parentAttr.height);
+
+  // remove indicator placeholder text
+  secG.removeChild(secG.getElementsByTagNameNS(NS, "text")[1]);
+
+  switch (type) {
+    case "next":
+      image.setAttributeNS(NS, "x", (8.9 / 10) * parentAttr.width);
+
+      secG.appendChild(image);
+
+      break;
+    case "previous":
+      image.setAttributeNS(NS, "x", (1 / 22) * parentAttr.width);
+
+      const [firstRectCloned, secRectCloned] = Object.entries(
+        doc.documentElement.getElementsByTagNameNS(NS, "rect")
+      )
+        .filter((e) => !isNaN(e[0]))
+        .map((e) => e[1].cloneNode());
+
+      Object.entries(firstG.getElementsByTagNameNS(NS, "rect"))
+        .filter((e) => !isNaN(e[0]))
+        .forEach((e) => firstG.removeChild(e[1]));
+
+      const { width: secRectClonedWidth } = Object.entries(
+        secRectCloned.attributes
+      )
+        .filter((e) => !isNaN(e[0]))
+        .map((e) => e[1])
+        .map((e) => ({
+          [e.name]: e.value,
+        }))
+        .reduce((curr, acc) => Object.assign(curr, acc));
+
+      firstRectCloned.setAttributeNS(NS, "x", secRectClonedWidth);
+      secRectCloned.setAttributeNS(NS, "x", "");
+
+      firstG.appendChild(secRectCloned);
+      firstG.appendChild(firstRectCloned);
+
+      const labelText = secG.getElementsByTagNameNS(NS, "text")[0];
+
+      secG.insertBefore(image, labelText);
+      labelText.setAttributeNS(NS, "x", (11.5 / 20) * 10 * parentAttr.width);
+
+      break;
+  }
+
+  return doc.toString();
+};
 
 module.exports = {
-  createCanvas,
-  getTextWidth,
-  DEFAULT_FONT,
-  GREY_RECT,
-  GREEN_RECT,
   NAVIGATION_TYPES,
-  nextImg: getImage("static/next.png"),
-  prevImg: getImage("static/previous.png"),
+  drawer,
 };

--- a/router/badge/index.js
+++ b/router/badge/index.js
@@ -26,17 +26,27 @@ const badge = (fastify, opts, done) => {
         const type = req.query.badgeType;
         const text = req.query.text;
 
+        if (!type || !text)
+          reply.code(400).send({
+            message: 'Diperlukan parameter "badgeType" dan "text"',
+          });
+
+        if (type === "")
+          reply
+            .code(400)
+            .send({ message: "Parameter badgeType tidak boleh kosong !" });
+
+        if (text === "")
+          reply
+            .code(400)
+            .send({ message: "Parameter text tidak boleh kosong !" });
+
         if (!NAVIGATION_TYPES.includes(type))
           reply.code(400).send({
             message: `Parameter "badgeType" tidak valid, diharapkan ${NAVIGATION_TYPES.map(
               (e) => `"${e}"`
             ).join(" atau ")}.`,
           });
-
-        if (text === null || text === undefined || text === "")
-          reply
-            .code(400)
-            .send({ message: "Paramter text tidak boleh kosong !" });
 
         const key = GITHUB_CACHE_KEY.badge.navigation(type, text);
         const dataCache = fastify.cache.get(key);

--- a/router/badge/index.js
+++ b/router/badge/index.js
@@ -1,13 +1,4 @@
-const {
-  createCanvas,
-  getTextWidth,
-  prevImg,
-  nextImg,
-  DEFAULT_FONT,
-  GREY_RECT,
-  GREEN_RECT,
-  NAVIGATION_TYPES,
-} = require("./config");
+const { NAVIGATION_TYPES, drawer } = require("./config");
 const { GITHUB_CACHE_KEY, EXPIRY_TTL } = require("../../config/constant");
 
 const badge = (fastify, opts, done) => {
@@ -51,7 +42,7 @@ const badge = (fastify, opts, done) => {
         const dataCache = fastify.cache.get(key);
 
         if (dataCache)
-          reply.header("Content-Type", "image/png").send(dataCache);
+          reply.header("Content-Type", "image/svg+xml").send(dataCache);
 
         done();
       },
@@ -62,54 +53,10 @@ const badge = (fastify, opts, done) => {
 
       const key = GITHUB_CACHE_KEY.badge.navigation(type, text);
 
-      // Init canvas
-      const greyRectWidth = getTextWidth(text);
-      const canvas = createCanvas(greyRectWidth + 25, 37);
-      const ctx = canvas.getContext("2d");
+      const result = drawer(text, type);
 
-      switch (req.query.badgeType) {
-        case "next":
-          // Grey Rectangle
-          ctx.fillStyle = GREY_RECT;
-          ctx.fillRect(0, 0, greyRectWidth, 37);
-
-          // Green Rectangle
-          ctx.fillStyle = GREEN_RECT;
-          ctx.fillRect(greyRectWidth - 10, 0, 37, 37);
-
-          // fill text from query string
-          ctx.font = DEFAULT_FONT;
-          ctx.fillStyle = "#ffffff";
-          ctx.fillText(text, 10, canvas.height / 2 + 5);
-
-          // Draw next image to canvas
-          nextImg(ctx, (9.89 / 10) * greyRectWidth, canvas.height * (2 / 10));
-
-          break;
-        case "previous":
-          // Grey Rectangle
-          ctx.fillStyle = GREY_RECT;
-          ctx.fillRect(37, 0, greyRectWidth, 37);
-
-          // Green Rectangle
-          ctx.fillStyle = GREEN_RECT;
-          ctx.fillRect(0, 0, 37, 37);
-
-          // fill text from query string
-          ctx.font = DEFAULT_FONT;
-          ctx.fillStyle = "#ffffff";
-          ctx.fillText(text, 47, canvas.height / 2 + 5);
-
-          // Draw previous image to canvas
-          prevImg(ctx, (1 / 32) * canvas.width, canvas.height * (2 / 10));
-
-          break;
-      }
-
-      const buffer = canvas.toBuffer("image/png");
-      reply.header("Content-Type", "image/png").send(buffer);
-
-      fastify.cache.set(key, buffer, EXPIRY_TTL.badge);
+      reply.header("Content-Type", "image/svg+xml").send(result);
+      fastify.cache.set(key, result, EXPIRY_TTL.badge);
     }
   );
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -40,17 +40,19 @@ const ajv = new Ajv({
   nullable: true,
 });
 
-const _testBuilder = (app) => (url, schema) => async () => {
+const _testBuilder = (app) => (url, schema, cacheKey) => async () => {
   const response = await app.inject({ method: "GET", url });
   const parsed = JSON.parse(response.body);
 
   const isArrayOfObject =
     Array.isArray(parsed) && parsed.map(isObject).every((e) => e === true);
   const valid = ajv.validate(schema, parsed);
+  const dataCache = app.cache.get(cacheKey);
 
   expect(response.statusCode).toBe(200);
   expect(isArrayOfObject).toBeTruthy();
   expect(valid).toBeTruthy();
+  expect(dataCache).toEqual(parsed);
 };
 
 module.exports = { build, ajv, _testBuilder };

--- a/test/router/badge.test.js
+++ b/test/router/badge.test.js
@@ -7,7 +7,7 @@ const { nextImg } = require("../../router/badge/config");
 
 const navigationUrl = "/badge/navigation";
 
-describe("'/badge' test bed", () => {
+describe("'/badge/navigation' test bed", () => {
   test("'/navigation' without all query parameter", async () => {
     const response = await app.inject({
       url: navigationUrl,
@@ -16,8 +16,22 @@ describe("'/badge' test bed", () => {
 
     expect(response.statusCode).toBe(400);
     expect(parsed).toEqual({
-      message:
-        'Parameter "badgeType" tidak valid, diharapkan "next" atau "previous".',
+      message: 'Diperlukan parameter "badgeType" dan "text"',
+    });
+  });
+
+  test("'/navigation' without 'badgeType' query parameter", async () => {
+    const response = await app.inject({
+      url: navigationUrl,
+      query: {
+        text: "Hello World",
+      },
+    });
+    const parsed = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(400);
+    expect(parsed).toEqual({
+      message: 'Diperlukan parameter "badgeType" dan "text"',
     });
   });
 
@@ -32,7 +46,29 @@ describe("'/badge' test bed", () => {
 
     expect(response.statusCode).toBe(400);
     expect(parsed).toEqual({
-      message: "Paramter text tidak boleh kosong !",
+      message: 'Diperlukan parameter "badgeType" dan "text"',
+    });
+  });
+
+  test.each([
+    { badgeType: "up" },
+    { badgeType: "down" },
+    { badgeType: "right" },
+    { badgeType: "left" },
+  ])('Check if badgeType "$badgeType" is invalid', async ({ badgeType }) => {
+    const response = await app.inject({
+      url: navigationUrl,
+      query: {
+        text: "Hello World",
+        badgeType,
+      },
+    });
+    const parsed = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(400);
+    expect(parsed).toEqual({
+      message:
+        'Parameter "badgeType" tidak valid, diharapkan "next" atau "previous".',
     });
   });
 
@@ -51,6 +87,8 @@ describe("'/badge' test bed", () => {
     const dataCache = app.cache.get(
       cacheKey.badge.navigation(query.badgeType, query.text)
     );
+
+    expect(response.statusCode).toBe(200);
 
     expect(response.headers["content-type"]).toBe("image/svg+xml");
     expect(isSvg(result)).toBeTruthy();

--- a/test/router/badge.test.js
+++ b/test/router/badge.test.js
@@ -1,4 +1,4 @@
-const { isText, isBinary, getEncoding } = require("istextorbinary");
+const isSvg = require("is-svg");
 const { build } = require("../helper");
 
 const app = build();
@@ -43,9 +43,7 @@ describe("'/badge' test bed", () => {
       },
     });
 
-    expect(response.headers["content-type"]).toBe("image/png");
-    expect(isBinary(null, response.body)).toBeTruthy();
-    expect(isText(null, response.body)).not.toBeTruthy();
-    expect(getEncoding(response.body)).toBe("binary");
+    expect(response.headers["content-type"]).toBe("image/svg+xml");
+    expect(isSvg(response.body)).toBeTruthy();
   });
 });

--- a/test/router/badge.test.js
+++ b/test/router/badge.test.js
@@ -2,6 +2,8 @@ const isSvg = require("is-svg");
 const { build } = require("../helper");
 
 const app = build();
+const { GITHUB_CACHE_KEY: cacheKey } = require("../../config/constant");
+const { nextImg } = require("../../router/badge/config");
 
 const navigationUrl = "/badge/navigation";
 
@@ -35,15 +37,26 @@ describe("'/badge' test bed", () => {
   });
 
   test("'/navigation' with all query parameter, should be passed", async () => {
+    const query = {
+      badgeType: "next",
+      text: "Hello World",
+    };
+
     const response = await app.inject({
       url: navigationUrl,
-      query: {
-        badgeType: "next",
-        text: "Hello World",
-      },
+      query,
     });
 
+    const result = response.body;
+    const dataCache = app.cache.get(
+      cacheKey.badge.navigation(query.badgeType, query.text)
+    );
+
     expect(response.headers["content-type"]).toBe("image/svg+xml");
-    expect(isSvg(response.body)).toBeTruthy();
+    expect(isSvg(result)).toBeTruthy();
+    expect(result).toEqual(dataCache);
+
+    expect(result.includes(query.text.toUpperCase())).toBeTruthy();
+    expect(result.includes(nextImg)).toBeTruthy();
   });
 });

--- a/test/router/leaderboard.test.js
+++ b/test/router/leaderboard.test.js
@@ -3,6 +3,7 @@ const { build, _testBuilder } = require("../helper");
 const app = build();
 
 const schema = require("../../router/leaderboard/opts");
+const { GITHUB_CACHE_KEY: cacheKey } = require("../../config/constant");
 
 describe('"/leaderboard" test bed', () => {
   const testBy = _testBuilder(app);
@@ -12,11 +13,15 @@ describe('"/leaderboard" test bed', () => {
   /* eslint-disable jest/expect-expect */
   test(
     "Get pull request leaderboard",
-    testBy("/leaderboard/pr", schema.pullRequests)
+    testBy("/leaderboard/pr", schema.pullRequests, cacheKey.leaderboard.pr)
   );
   test(
     "Get contribution leaderboard",
-    testBy("/leaderboard/contribution", schema.contribution)
+    testBy(
+      "/leaderboard/contribution",
+      schema.contribution,
+      cacheKey.leaderboard.contribution
+    )
   );
   /* eslint-enable jest/expect-expect */
 });

--- a/test/router/main.test.js
+++ b/test/router/main.test.js
@@ -3,16 +3,23 @@ const { build, ajv, _testBuilder } = require("../helper");
 const app = build();
 
 const schema = require("../../router/main/opts");
+const { GITHUB_CACHE_KEY: cacheKey } = require("../../config/constant");
 
 describe("Non dynamic route, should be passed without any problem", () => {
   const testBy = _testBuilder(app);
 
   /* eslint-disable jest/expect-expect */
-  test("Get bellshade public members", testBy("/", schema.members));
-  test("Get bellshade all public repos", testBy("/repos", schema.repos));
+  test(
+    "Get bellshade public members",
+    testBy("/", schema.members, cacheKey.members)
+  );
+  test(
+    "Get bellshade all public repos",
+    testBy("/repos", schema.repos, cacheKey.repos)
+  );
   test("Get bellshade all public repos contributors", async () => {
     jest.setTimeout(30000);
-    await testBy("/contributors", schema.contributors);
+    await testBy("/contributors", schema.contributors, cacheKey.contributors);
   });
   /* eslint-enable jest/expect-expect */
 });
@@ -54,8 +61,10 @@ describe("Dynamic route, it will be check thruthiness and status code", () => {
     });
     const parsed = JSON.parse(response.body);
     const valid = ajv.validate(schema.prCheck, parsed);
+    const dataCache = app.cache.get(cacheKey.prInfo("reacto11mecha"));
 
     expect(response.statusCode).toBe(200);
     expect(valid).toBeTruthy();
+    expect(parsed).toEqual(dataCache);
   });
 });

--- a/test/utils/navigationDrawer.test.js
+++ b/test/utils/navigationDrawer.test.js
@@ -24,6 +24,7 @@ describe("SVG Drawer function test bed", () => {
   it("will be running on default type mode", () => {
     const result = drawer(text);
 
+    expect(isSvg(result)).toBeTruthy();
     expect(result.includes(text.toUpperCase())).toBeTruthy();
     expect(result.includes(nextImg)).toBeTruthy();
   });
@@ -31,6 +32,7 @@ describe("SVG Drawer function test bed", () => {
   it("will be running on previous type mode", () => {
     const result = drawer(text, "previous");
 
+    expect(isSvg(result)).toBeTruthy();
     expect(result.includes(text.toUpperCase())).toBeTruthy();
     expect(result.includes(prevImg)).toBeTruthy();
   });

--- a/test/utils/navigationDrawer.test.js
+++ b/test/utils/navigationDrawer.test.js
@@ -1,0 +1,37 @@
+const { drawer, nextImg, prevImg } = require("../../router/badge/config");
+const isSvg = require("is-svg");
+
+describe("SVG Drawer function test bed", () => {
+  const text = "Hello World";
+
+  it("expect throw an error 'Text is Required'", () => {
+    const error = new Error("Text is Required");
+
+    expect(() => drawer()).toThrow(error);
+    expect(() => drawer("")).toThrow(error);
+  });
+
+  it("expect throw an error 'Invalid Type'", () => {
+    const error = new Error("Invalid Type");
+
+    expect(() => drawer(text, "")).toThrow(error);
+    expect(() => drawer(text, "up")).toThrow(error);
+    expect(() => drawer(text, "down")).toThrow(error);
+    expect(() => drawer(text, "left")).toThrow(error);
+    expect(() => drawer(text, "right")).toThrow(error);
+  });
+
+  it("will be running on default type mode", () => {
+    const result = drawer(text);
+
+    expect(result.includes(text.toUpperCase())).toBeTruthy();
+    expect(result.includes(nextImg)).toBeTruthy();
+  });
+
+  it("will be running on previous type mode", () => {
+    const result = drawer(text, "previous");
+
+    expect(result.includes(text.toUpperCase())).toBeTruthy();
+    expect(result.includes(prevImg)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Karena gambar yang dihasilin sama node canvas di pr #14, akhirnya dipindah ke `badge-maker` dimana itu library yang dipake shields.io buat mereka hasilin badge yang dipake orang orang saat ini. PR ini juga nambahin beberapa unit test baru biar gampang deteksi error logika (dan beberapa ketemu error logika karena unit test ini).

Contoh badge (gambar di zoom 500x):

![image](https://user-images.githubusercontent.com/48118327/143666154-0a7f4e79-76a8-4ff9-88a4-b7367d2cee8b.png)

![image](https://user-images.githubusercontent.com/48118327/143666179-1d11b1f7-1988-4a96-a38d-39f2b7ad80aa.png)


Belum di coba di github lewat ngrok, segara dicoba setelah open pr ini